### PR TITLE
Fix/tkinter canvas error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- Open source release
-- Comprehensive documentation
-- Setup script for easy installation
-- Contributing guidelines
-- MIT License
-
-### Changed
-- Removed sensitive Firebase credentials
-- Added template for Firebase configuration
-- Updated requirements.txt with version constraints
-- Improved .gitignore for security
-
 ### Fixed
 - Fixed CustomTkinter canvas error that prevented application startup
 - Added missing numpy dependency for screen_share_service
@@ -27,11 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Properly initialized window_thumbnails_service
 - Improved error handling for icon creation with PIL fallback
 - Added fallback emoji icons when image creation fails
-
-### Security
-- Removed hardcoded API keys and credentials
-- Added template files for configuration
-- Enhanced security documentation
 
 ## [1.2.4] - 2024-01-XX
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated requirements.txt with version constraints
 - Improved .gitignore for security
 
+### Fixed
+- Fixed CustomTkinter canvas error that prevented application startup
+- Added missing numpy dependency for screen_share_service
+- Added missing winreg import for autostart functionality
+- Properly initialized window_thumbnails_service
+- Improved error handling for icon creation with PIL fallback
+- Added fallback emoji icons when image creation fails
+
 ### Security
 - Removed hardcoded API keys and credentials
 - Added template files for configuration

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ server/
    - Ensure you're running as Administrator
    - Check if another instance is already running
    - Verify Python and dependencies are installed
+   - If you get a canvas error, ensure all dependencies from requirements.txt are installed
 
 2. **Connection issues**
    - Check firewall settings
@@ -142,6 +143,11 @@ server/
 3. **Screen sharing not working**
    - Ensure you have the latest graphics drivers
    - Check Windows display settings
+
+4. **PyInstaller build issues**
+   - Ensure all dependencies are installed: `pip install -r requirements.txt`
+   - Use the provided `server_gui.spec` file for building
+   - Run: `pyinstaller --clean server_gui.spec`
 
 ### Logs
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ Pillow>=11.1.0
 pystray>=0.19.5
 psutil>=5.9.0
 pyperclip>=1.9.0
-pynput>=1.7.6 
+pynput>=1.7.6
+numpy>=1.21.0 


### PR DESCRIPTION
- Fix CustomTkinter canvas error by replacing create_icon method with PIL-based implementation
- Add fallback emoji icons when image icons fail to load
- Add missing numpy dependency for screen_share_service
- Add missing winreg import for autostart functionality
- Initialize window_thumbnails_service properly
- Improve error handling for icon creation

## Description

The main issue was a `'!ctkcanvas' does not exist` error caused by incorrect usage of CustomTkinter's canvas system, along with several missing dependencies and imports.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Security enhancement

## Testing

- [x] Tested on Windows 10/11
- [x] Tested with Python 3.8+
- [x] All functionality works correctly
- [x] No sensitive data is included
- [x] Documentation is updated

## Checklist

- [ ] Code follows PEP 8 style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] No sensitive data included
- [x] Changes are tested on Windows
- [x] Dependencies are properly specified in requirements.txt
- [x] Error handling is implemented
- [x] Logging is appropriate

## Additional Notes

Any additional information that reviewers should know about this pull request.

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Related Issues

Closes #(issue number) 